### PR TITLE
Correção de bugs de tradução de instruções individuais

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@
 </p>
 
 ## Descrição
-Assembler web para um simulador do Altair 8800 - Projeto para a disciplina de Arquitetura de Computadores
+Assembler web para um simulador do Altair 8800 - Projeto para a disciplina de Arquitetura de Computadores <br>
 Link para o assembler: <a target="_blank" href="https://florindorian.github.io/assembler-altair8800/">Altair 8800 Assembler</a>

--- a/scripts/InstructionSet.js
+++ b/scripts/InstructionSet.js
@@ -1,13 +1,15 @@
 export default class InstructionSet {
     #regex = [
-        // Instrução com 1 campo
-        /^([A-Z]{2,4})$/,
-        // Instrução com 2 campos, sendo que a inicial do primeiro campo é J, C ou R e o complemento é NZ|Z|NC|C|PO|PE|P|M
-        /^((?:J|C|R))((?:NZ|Z|NC|C|PO|PE|P|M)) ([0-9A-Z]{4})$/,
-        // Instrução com 2 campos genéricos
-        /^([A-Z]{2,4}) ([0-9A-Z]{1,})$/,
-        // Instrução com 3 campos, sendo que os dois últimos são separados por vírgula
-        /^([A-Z]{2,4}) ([0-9A-Z]{1,}),([0-9A-Z]{1,})$/
+        // Instrução com 1 parte
+        /^(?!(?:J|C|R)(?:NZ|Z|NC|C|PO|PE|P|M)$)([A-Z]{2,4})$/,
+        // Instrução com 1 parte, a qual começa com a letra R seguida de uma condição
+        /^(R)(NZ|Z|NC|C|PO|PE|P|M)$/,
+        // Instrução com 2 partes, com J ou C seguido de uma condição na 1ª e um argumento constante na 2ª
+        /^(J|C)(NZ|Z|NC|C|PO|PE|P|M) ([0-9A-F]{4})$/,
+        // Instrução com 2 partes genéricas
+        /^([A-Z]{2,4}) ([0-9A-F]+)$/,
+        // Instrução com 3 partes, sendo que as duas últimas são separadas por vírgula
+        /^([A-Z]{2,4}) ([0-9A-F]+),([0-9A-F]+)$/
     ];
 
     #mnemonics = {
@@ -19,8 +21,8 @@ export default class InstructionSet {
         'STA': ['lb hb', '00110010 lb hb'],
         'LHLD': ['lb hb', '00101010 lb hb'],
         'SHLD': ['lb hb', '00100010 lb hb'],
-        'LDAX': ['RP', '00RP1010 RP'], // Considerar a obs *1 e TODO: implementação
-        'STAX': ['RP', '00RP0010 RP'], // Considerar a obs *1 e TODO: implementação
+        'LDAX': ['RP', '00RP1010'], // Considerar a obs *1 e TODO: implementação
+        'STAX': ['RP', '00RP0010'], // Considerar a obs *1 e TODO: implementação
         'XCHG': ['', '11101011'],
         'ADD': ['SSS', '10000SSS'],
         'ADI': ['db', '11000110 db'],
@@ -39,11 +41,11 @@ export default class InstructionSet {
         'ANA': ['SSS', '10100SSS'],
         'ANI': ['db', '11100110 db'],
         'ORA': ['SSS', '10110SSS'],
-        'ORI': ['db', '11110110 db'], //Em http://dunfield.classiccmp.org//r/8080.txt está errado, aqui está corrigido
+        'ORI': ['db', '11110110 db'], // Em http://dunfield.classiccmp.org//r/8080.txt está errado, aqui está corrigido
         'XRA': ['SSS', '10101SSS'],
         'XRI': ['db', '11101110 db'],
         'CMP': ['SSS', '10111SSS'],
-        'CPI': ['db', '11111110 db'], //Em http://dunfield.classiccmp.org//r/8080.txt está errado, aqui está corrigido
+        'CPI': ['db', '11111110 db'], // Em http://dunfield.classiccmp.org//r/8080.txt está errado, aqui está corrigido
         'RLC': ['', '00000111'],
         'RRC': ['', '00001111'],
         'RAL': ['', '00010111'],
@@ -56,11 +58,11 @@ export default class InstructionSet {
         'CALL': ['lb hb', '11001101 lb hb'],
         'C': ['ccc,lb hb', '11ccc100 lb hb'],
         'RET': ['', '11001001'],
-        'R': ['ccc', '11CCC000'], //OBS!!! Provavelmente a 2ª regex não corresponde a essa instrução, devido não possuir um argumento do tipo ([0-9A-Z]{4}); TODO: Corrigir a regex ou criar uma nova
+        'R': ['ccc', '11ccc000'],
         'RST': ['nnn', '11nnn111'],
         'PCHL': ['', '11101001'],
-        'PUSH': ['RP', '11RP0101 RP'], // Considerar a obs *2 e TODO: implementação
-        'POP': ['RP', '11RP0001 RP'], // Considerar a obs *2 e TODO: implementação
+        'PUSH': ['RP', '11RP0101'], // Considerar a obs *2 e TODO: implementação
+        'POP': ['RP', '11RP0001'], // Considerar a obs *2 e TODO: implementação
         'XTHL': ['', '11100011'],
         'SPHL': ['', '11111001'],
         'IN': ['pa', '11011011 pa'],

--- a/scripts/Translator.js
+++ b/scripts/Translator.js
@@ -38,7 +38,7 @@ export default class Translator {
 
     codificarArgs(linhaDividida) {
         const qtdGrupos = linhaDividida.grupos.length - 1;
-        let grupo2, grupo3;
+        let grupo2, grupo3, grupo1;
 
         if (qtdGrupos > 1) {
             let regex = this.#instructionSet.regex;
@@ -46,44 +46,48 @@ export default class Translator {
             let regPairs = this.#instructionSet.regPairs;
             let conditions = this.#instructionSet.conditions;
 
+            grupo1 = linhaDividida.grupos[1];
             grupo2 = linhaDividida.grupos[2];
             if (qtdGrupos > 2) {
                 grupo3 = linhaDividida.grupos[3];
             }
 
             //Analisando os 4 formatos possíveis de instruções com base nas respectivas regex
-            if (linhaDividida.regex === regex[3]) {
-                // REGEX 3: Aplicar codificações para: registers, regPair
-                // CODIFICANDO REGISTRADORES
-                if (grupo2 in registers) {
-                    grupo2 = registers[grupo2]; //register: code
+            if (linhaDividida.regex === regex[3] || linhaDividida.regex === regex[4]) {
+                // REGEX 3 e 4: Aplicar codificações para: registers, regPair
+                // CODIFICANDO CONSTANTES
+                
+                if (grupo1 === "RST") {
+                    //Caso seja o argumento da instrução RST, ou seja, 1,2,3,...,7
+                    let zerosEsquerda = "";
+                    if (parseInt(grupo2,10) < 2) {
+                        zerosEsquerda = "00";
+                    } else if (parseInt(grupo2,10) < 4) {
+                        zerosEsquerda = "0";
+                    }
+                    grupo2 = zerosEsquerda + parseInt(grupo2,10).toString(2);
                 }
-                if (grupo3 in registers && qtdGrupos > 2) { //TESTAR!!!: retirar qtdGrupos > 2
-                    grupo3 = registers[grupo3]; //register: code
-                }
+                
 
-                //CODIFICANDO PARES DE REGISTRADORES
-                if (grupo2 in regPairs) {
-                    grupo2 = regPairs[grupo2]; //regPair: code
-                }
-            } else if (linhaDividida.regex === regex[2]) {
-                // REGEX 2: Aplicar codificações para: registradores, regPair
                 // CODIFICANDO REGISTRADORES
                 if (grupo2 in registers) {
                     grupo2 = registers[grupo2]; //register: code
+                }
+                if (grupo3 in registers && qtdGrupos > 2) {
+                    grupo3 = registers[grupo3]; //register: code
                 }
 
                 // CODIFICANDO PARES DE REGISTRADORES
                 if (grupo2 in regPairs) {
                     grupo2 = regPairs[grupo2]; //regPair: code
                 }
-            } else if (linhaDividida.regex === regex[1]) {
-                // REGEX 1: Aplicar codificações para: condições
+            } else if (linhaDividida.regex === regex[1] || linhaDividida.regex === regex[2]) {
+                // REGEX 1 e 2: Aplicar codificações para: condições
                 // CODIFICANDO CONDIÇÕES
                 if (grupo2 in conditions) {
                     grupo2 = conditions[grupo2]; //condition: code
                 }
-            }
+            } 
             // REGEX 0: não precisa ser tratada, porque não possui argumentos
 
             linhaDividida.grupos[2] = grupo2;

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -10,6 +10,7 @@ bt_traduzir.onclick = () => {
     let codigoMaquina = '';
     
     for (let linha of linhas) {
+        linha = linha.trim(); //Retira espaços em branco no início e no fim da instrução lida
         codigoMaquina += translator.traduzir(linha) + ' ';
     }
     output_area.textContent = codigoMaquina;


### PR DESCRIPTION
Correção das regex existentes e criação de uma nova. Correção das regras dos mnemônicos e uso de trim() para tirar espaços em branco antes e depois de cada instrução lida.